### PR TITLE
Fix h5pyf not found when flushing HDF5 output processor

### DIFF
--- a/libsoundannotator/streamboard/processors/output/oldfileout.py
+++ b/libsoundannotator/streamboard/processors/output/oldfileout.py
@@ -178,6 +178,6 @@ class FileOutputProcessor(processor.OutputProcessor):
             dset.attrs.create(str(dset.shape[shapeDim] + 1), str(chunk.dataGenerationTime))
     
     def flushAndClose(self):
-        if hasattr(self, 'h5pyf'):
+        if getattr(self, 'h5pyf', None) is not None:
             self.h5pyf.flush()
             self.h5pyf.close()

--- a/libsoundannotator/streamboard/processors/output/oldfileout.py
+++ b/libsoundannotator/streamboard/processors/output/oldfileout.py
@@ -46,10 +46,7 @@ class FileOutputProcessor(processor.OutputProcessor):
 
     def finalize(self):
         self.logger.info("Finalize in FileOutputProcessor")
-        if self.h5pyf:
-            self.logger.info("Flushing and closing file handler")
-            self.h5pyf.flush()
-            self.h5pyf.close()
+        self.flushAndClose()
 
     def prerun(self):
         super(FileOutputProcessor, self).prerun()
@@ -93,9 +90,7 @@ class FileOutputProcessor(processor.OutputProcessor):
         #close handle to prevent corruption
         self.logger.info('Closing h5py handle')
         
-        if self.h5pyf:
-            self.h5pyf.flush()
-            self.h5pyf.close()
+        self.flushAndClose()
 
     def addChunkToDataset(self, h5pyf, key, chunk):
         maxshape = (None,)
@@ -181,3 +176,8 @@ class FileOutputProcessor(processor.OutputProcessor):
         #every 100 chunks, add the generation time to the first sample of the new chunk
         if chunk.number % 100 == 0:
             dset.attrs.create(str(dset.shape[shapeDim] + 1), str(chunk.dataGenerationTime))
+    
+    def flushAndClose(self):
+        if hasattr(self, 'h5pyf'):
+            self.h5pyf.flush()
+            self.h5pyf.close()


### PR DESCRIPTION
In case finalize is called on the file output processor, sometimes self.h5pyf is not found. In this case, using hasattr prevents Python throwing an error. For convenience, I've created a class method that can be called to flush and close the file handle