### PR TITLE
Change continuity when full chunk cannot be read from wav input

### DIFF
--- a/libsoundannotator/streamboard/processors/input/wav.py
+++ b/libsoundannotator/streamboard/processors/input/wav.py
@@ -97,6 +97,10 @@ class WavProcessor(processor.InputProcessor):
     def generateData(self):
         frames = self.reader.readFrames(self.chunksize)
 
+        # when we cannot read a full chunk, set continuity to last
+        if len(frames) < self.chunksize:
+            self.continuity = Continuity.last
+
         # If specified, add some noise to prevent NaN from occuring due to log(E)
         if self.AddWhiteNoise:
             frames += self.generateWhitenoise(frames)


### PR DESCRIPTION
When the wav input processor cannot read a full chunk, this means that the end of the file has been reached. In this case, mark the continuity as 'last'.